### PR TITLE
Ajout lsarrazi

### DIFF
--- a/JS/2-Impot.fr/README.md
+++ b/JS/2-Impot.fr/README.md
@@ -28,6 +28,7 @@ Pour l'exercice final on prendra le problème en sens inverse et on permettra à
 ## Vanilla
 
 - @meschac38700 : https://codesandbox.io/s/purple-frost-b4c8g?file=/app.js
+- @lsarrazi : [PlayCode](https://playcode.io/659406)
 
 ## React
 


### PR DESCRIPTION
Implémentation du niveau "boss final" en Vanilla. 
Les formules suivent précisément les résultats des calculs du document fournis. (en théorie)
Changer les champs "montant d'imposition" ou "revenu net d’impôt" permet d'effectuer la fonction inverse.
Les changements sont effectués de manière instantané après un `keyup`.
Les fonctions inverses ont étaient construites à partir de quelques observations mathématiques intuitives, je n'ai pas à ma connaissance de méthode systématique pour trouver l'inverse de ce genre de fonctions.
Heureux d'avoir participé à ce challenge.